### PR TITLE
001-migrate-log-location.sh: Empty /var/contiv/log ends up with cp: can't stat '/var/contiv/log/*': No such file or directory

### DIFF
--- a/netplugin-init/common/001-migrate-log-location.sh
+++ b/netplugin-init/common/001-migrate-log-location.sh
@@ -3,7 +3,7 @@ set -uex
 
 mkdir -p /opt/contiv/ /var/log/contiv
 
-if [ -d /var/contiv/log ]; then
+if [ -d /var/contiv/log ] && [ "$(ls -A /var/contiv/log)" ]; then
     # /var/contiv/log/ is deprecated, move all data to /var/log/contiv
     cp -a /var/contiv/log/* /var/log/contiv/
     echo "INFO: Copied contiv log from /var/contiv/log (deprecated) to /var/log/contiv"


### PR DESCRIPTION
When /var/contiv/log exists but is empty `cp -a /var/contiv/log/* /var/log/contiv/` fails and netplugin is not initialized (but causes Init:CrashLoopBackOff in k8s for example)